### PR TITLE
Support accepting group ID as the part of the location field

### DIFF
--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -33,6 +33,7 @@ function getWebsiteFormData(body) {
     }
 
     return {
+        'request': body['request'],
         'name': body['full_name'],
         'phone': body['phone'],
         'location': location,

--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -33,13 +33,16 @@ function getWebsiteFormData(body) {
     }
 
     return {
+        'name': body['namek'],
+        'phone': body['phone'],
         'location': location,
-        'neighborhood': req['neighborhood'],
+        'neighborhood': body['neighborhood'],
         'zelos_group_id': zelosGroupId,
         // todo: both email address and physical address are called "address" in the form. We should fix this.
-        'address': req['address'],
-        'how-did-you-hear': req['how-did-you-hear'],
-        'how-did-you-hear-other': req['how-did-you-hear-other'],
+        'address': body['address'],
+        'email_address': body['email_address'],
+        'how-did-you-hear': body['how-did-you-hear'],
+        'how-did-you-hear-other': body['how-did-you-hear-other'],
     };
 }
 

--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -53,11 +53,12 @@ app.get('/', (req, res) => {
 
 // Get data from CF7 Webhook and create trello card
 app.post('/', async (req, res) => {
+    console.log('[i] New request from CF7');
     const trello = new Trello();
     await trello.init();
     try {
         const data = getWebsiteFormData(req.body);
-        console.log('[i] New request from CF7 ' + JSON.stringify(data));
+        console.log('[i] getWebsiteFormData: ' + JSON.stringify(data));
         await trello.newCard(data);
         res.send("Success!\n");
     } catch (err) {

--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -1,3 +1,5 @@
+// todo danielz: remove this later
+require('@google-cloud/debug-agent').start();
 const express = require('express');
 const app = express();
 const Trello = require('./models/Trello');

--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -28,7 +28,7 @@ function getWebsiteFormData(body) {
     let zelosGroupId = null;
     // Due to difficulties adopting CF7 behaviour, we're temporarily using the location field to send both
     // the name of the city and its  Zelos group ID, separated by ",,". We're not sending this for all values.
-    if (location.contains(LOCATION_SEP)) {
+    if (location.includes(LOCATION_SEP)) {
         const strings = location.split(LOCATION_SEP);
         location = strings[0];
         zelosGroupId = strings[1];
@@ -45,7 +45,7 @@ function getWebsiteFormData(body) {
         'email_address': body['email_address'],
         'how-did-you-hear': body['how-did-you-hear'],
         'how-did-you-hear-other': body['how-did-you-hear-other'],
-    };
+    }
 }
 
 // Default route

--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -33,12 +33,11 @@ function getWebsiteFormData(body) {
     }
 
     return {
-        'name': body['namek'],
+        'name': body['full_name'],
         'phone': body['phone'],
         'location': location,
         'neighborhood': body['neighborhood'],
         'zelos_group_id': zelosGroupId,
-        // todo: both email address and physical address are called "address" in the form. We should fix this.
         'address': body['address'],
         'email_address': body['email_address'],
         'how-did-you-hear': body['how-did-you-hear'],

--- a/cf7_to_trello/index.js
+++ b/cf7_to_trello/index.js
@@ -1,5 +1,3 @@
-// todo danielz: remove this later
-require('@google-cloud/debug-agent').start();
 const express = require('express');
 const app = express();
 const Trello = require('./models/Trello');

--- a/cf7_to_trello/package.json
+++ b/cf7_to_trello/package.json
@@ -8,11 +8,12 @@
     "daemon": "pm2 start index.js -e ./error.log -o ./output.log",
     "live": "PORT=8999 nodemon index.js"
   },
-  "author": "Viktor Lillemäe",
+  "author": "Paliec Majas",
   "license": "ISC",
   "dependencies": {
     "@google-cloud/datastore": "^5.1.0",
     "@google-cloud/storage": "^4.6.0",
+    "@google-cloud/debug-agent": "^4.2.2",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "express-validator": "^6.4.0",

--- a/cf7_to_trello/package.json
+++ b/cf7_to_trello/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@google-cloud/datastore": "^5.1.0",
     "@google-cloud/storage": "^4.6.0",
-    "@google-cloud/debug-agent": "^4.2.2",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "express-validator": "^6.4.0",

--- a/trello_monitor/index.js
+++ b/trello_monitor/index.js
@@ -62,17 +62,17 @@ app.post(`/${endpoint}`, async (req, res) => {
         const workspace = new Zelos();
         await workspace.init();
 
-        // Location can be a string name or a number representing Zelos group ID
         const location = taskData.location;
-        let groupId;
-        if (isNaN(location)) {
+        let groupId = taskData.zelos_group_id;
+
+        if (!isNaN(groupId)) {
+          // Search for the Zelos group ID if it wasn't already supplied
           const fullLocation = !taskData.neighborhood
               ? location
               : `${location} - ${taskData.neighborhood}`;
           groupId = await workspace.findGroup(fullLocation);
-        } else {
-          groupId = location;
         }
+
         const task = await workspace.newTask(taskData, [groupId]);
         if (task instanceof Error) {
             res.send('Err');

--- a/trello_monitor/models/Zelos.js
+++ b/trello_monitor/models/Zelos.js
@@ -63,7 +63,7 @@ class Zelos {
         }
         const instruction = [];
         Object.keys(details).forEach(item => {
-            if (item === 'phone' || item === 'address' || item === 'full_name' || item === 'neighborhood') {
+            if (item === 'phone' || item === 'address' || item === 'name' || item === 'neighborhood') {
                 instruction.push(`${item.capitalize()}: ${details[item]}`);
             }
         });

--- a/trello_monitor/models/Zelos.js
+++ b/trello_monitor/models/Zelos.js
@@ -63,7 +63,7 @@ class Zelos {
         }
         const instruction = [];
         Object.keys(details).forEach(item => {
-            if (item === 'phone' || item === 'address' || item === 'name' || item === 'neighborhood') {
+            if (item === 'phone' || item === 'address' || item === 'full_name' || item === 'neighborhood') {
                 instruction.push(`${item.capitalize()}: ${details[item]}`);
             }
         });

--- a/trello_monitor/models/Zelos.js
+++ b/trello_monitor/models/Zelos.js
@@ -8,6 +8,9 @@ const config = {
     "workspace": process.env.ZELOS_WORKSPACE
 };
 
+/**
+ * Zelos API documentation can be found here: https://paliecmajas.zelos.space/api/documentation
+ */
 class Zelos {
     constructor() {
         this.url = `https://${config.workspace}.zelos.space`;


### PR DESCRIPTION
https://trello.com/c/nKE9u6UA/69-change-volunteer-groups-on-zelos-and-our-website

https://trello.com/c/EWNsDoqR/76-adjust-trello-zelos-integration-make-sure-that-jelgava-and-jaunjelgava-doesnt-go-to-the-opposite-group

I'm not very happy with this implementation but it's a step forward and will allow us to finally close the two bugs above.

Basically, we want to separate relying on the name on the website accurately reflecting the name in Zelos. This leads to all kind of potential problems including [this one](https://trello.com/c/EWNsDoqR/76-adjust-trello-zelos-integration-make-sure-that-jelgava-and-jaunjelgava-doesnt-go-to-the-opposite-group). Instead, we'd like to have "one source of truth" but that is difficult because of all the different systems we use. I took an approach where at least the (kind of) single source of truth is the contact form. I wanted to use the CF7 pipes [functionality](https://contactform7.com/selectable-recipient-with-pipes/) to gather both the name and the ID and pass it on, but the webhooks plugin doesn't support it. I'm sure there's a way around this but I think for now we should go with this and solve it later.

You can see a demo contact form [here](https://paliec-majas.lv/wp-admin/admin.php?page=wpcf7&post=1752&active-tab=0) and how it looks [here](https://paliec-majas.lv/?page_id=1754&preview=true).